### PR TITLE
Added option for logging debug information to a file/console

### DIFF
--- a/FlatOut2/InstanceSettings.cpp
+++ b/FlatOut2/InstanceSettings.cpp
@@ -48,7 +48,6 @@ InstanceSettings* InstanceSettings::InitSettings(int instanceID)
 	instSet->instanceID = instanceID;
 	instSet->procID = GetCurrentProcessId();
 	instSet->instanceController = m_instanceSettings->m_settings->globals.controller[instanceID];
-	instSet->attachConsole = m_instanceSettings->m_settings->globals.attachConsole[instanceID];
 	instSet->windowPos = m_instanceSettings->m_settings->globals.windowPos[instanceID];
 	if (m_instanceSettings->m_instanceID == INSTANCESETTINGS_HOSTINST)
 	{

--- a/FlatOut2/InstanceSettings.h
+++ b/FlatOut2/InstanceSettings.h
@@ -14,7 +14,6 @@ struct SET_InstanceSettings
 	GUID instanceController;
 	HWND mainHwnd = NULL;
 	DWORD procID = NULL;
-	BOOL attachConsole = FALSE;
 	RECT windowPos;
 	CDirect3D9Hook* d3d = NULL;
 	CDirectInput8Hook* directInput = NULL;
@@ -33,8 +32,9 @@ struct SET_GlobalSettings
 	BOOL useInputEmulation;
 	BOOL skipIntros;
 	SET_NetSettings network;
+	Logging::Level logFileVerbosity;
+	Logging::Level consoleVerbosity;
 	GUID controller[FO2_MaxClientCount];
-	BOOL attachConsole[FO2_MaxClientCount];
 	RECT windowPos[FO2_MaxClientCount];
 };
 
@@ -59,6 +59,8 @@ public:
 	int GetInstanceID();
 	int GetInstanceID(u_short clientPortH);
 	u_short GetInstanceVirtPort(int instanceID);
+	Logging::Level GetConsoleVerbosity() { return m_settings->globals.consoleVerbosity; }
+	Logging::Level GetLogFileVerbosity() { return m_settings->globals.logFileVerbosity; }
 	void SetInstanceVirtPort(u_short clientPortH);
 	void SetGameWindowHandle(HWND window);
 	void SetDirect3DHook(CDirect3D9Hook* d3d);

--- a/FlatOut2/Logging.cpp
+++ b/FlatOut2/Logging.cpp
@@ -2,6 +2,10 @@
 #include "Logging.h"
 
 Logging::Logging() {
+	if (InstanceSettings::GetSettings()->GetLogFileVerbosity() == Off) {
+		return;
+	}
+
 	DWORD waitResult;
 	m_createMappingsMutex = CreateMutex(NULL, FALSE, LOGGING_FILECREATEMUTEX);
 	m_bufferMutex = CreateMutex(NULL, FALSE, LOGGING_WRITEMUTEX);
@@ -42,7 +46,13 @@ void Logging::log(Logging::Level level, const char* tag, std::string msg) {
 	std::ostringstream formattedMsg;
 	auto settings = InstanceSettings::GetSettings();
 	formattedMsg << '[' << tag << "|" << settings->GetInstanceID() << "] " << msg << std::endl;
-	writeBuffer(formattedMsg.str());
+	if (InstanceSettings::GetSettings()->GetLogFileVerbosity() >= level) {
+		writeBuffer(formattedMsg.str());
+	}
+
+	if (InstanceSettings::GetSettings()->GetConsoleVerbosity() >= level) {
+		std::cout << formattedMsg.str();
+	}
 }
 
 void Logging::writeBuffer(std::string formattedMsg) {

--- a/FlatOut2/Logging.h
+++ b/FlatOut2/Logging.h
@@ -18,13 +18,13 @@ public:
 		static Logging instance;
 		return instance;
 	}
+	enum Level : int { Off, Error, Warn, Info, Debug, Trace };
 	void error(const char* tag, std::string msg) { log(Level::Error, tag, msg); }
 	void warn(const char* tag, std::string msg) { log(Level::Warn, tag, msg); }
 	void info(const char* tag, std::string msg) { log(Level::Info, tag, msg); }
 	void debug(const char* tag, std::string msg) { log(Level::Debug, tag, msg); }
 	void trace(const char* tag, std::string msg) { log(Level::Trace, tag, msg); }
 private:
-	enum Level { Off, Error, Warn, Info, Debug, Trace };
 	Logging();
 	void log(Level level, const char* tag, std::string msg);
 	void writeBuffer(std::string formattedMsg);

--- a/FlatOut2/User32Detours.cpp
+++ b/FlatOut2/User32Detours.cpp
@@ -201,7 +201,7 @@ HWND WINAPI MyCreateWindowExA(
 	LPVOID lpParam)
 {
 	SET_InstanceSettings instSet = InstanceSettings::GetSettings()->GetLocalSettings();
-	if (instSet.attachConsole)
+	if (InstanceSettings::GetSettings()->GetConsoleVerbosity() > Logging::Off)
 	{
 		AllocConsole();
 		AttachConsole(GetCurrentProcessId());

--- a/Launcher/Setup.Designer.cs
+++ b/Launcher/Setup.Designer.cs
@@ -32,7 +32,6 @@
             this.ConfigTabControl = new System.Windows.Forms.TabControl();
             this.TabGeneralSettings = new System.Windows.Forms.TabPage();
             this.InputSkipIntros = new System.Windows.Forms.CheckBox();
-            this.InputAttachConsole = new System.Windows.Forms.CheckBox();
             this.InputResoSelect = new System.Windows.Forms.ComboBox();
             this.InputInstanceCount = new System.Windows.Forms.NumericUpDown();
             this.LabelResolution = new System.Windows.Forms.Label();
@@ -43,6 +42,11 @@
             this.InputControllerSelect = new System.Windows.Forms.ComboBox();
             this.ControllerBTResetAll = new System.Windows.Forms.Button();
             this.ControllerPlayerList = new System.Windows.Forms.ListView();
+            this.TabDebugging = new System.Windows.Forms.TabPage();
+            this.ConsoleVerbositySelect = new System.Windows.Forms.ComboBox();
+            this.LabelConsoleVerbosity = new System.Windows.Forms.Label();
+            this.LogFileVerbositySelect = new System.Windows.Forms.ComboBox();
+            this.LabelDebugFileVerb = new System.Windows.Forms.Label();
             this.ButtonLaunch = new System.Windows.Forms.Button();
             this.NewVerLink = new System.Windows.Forms.LinkLabel();
             this.ConfigTabControl.SuspendLayout();
@@ -50,12 +54,14 @@
             ((System.ComponentModel.ISupportInitialize)(this.InputInstanceCount)).BeginInit();
             this.TabController.SuspendLayout();
             this.ControllerOptionsPanel.SuspendLayout();
+            this.TabDebugging.SuspendLayout();
             this.SuspendLayout();
             // 
             // ConfigTabControl
             // 
             this.ConfigTabControl.Controls.Add(this.TabGeneralSettings);
             this.ConfigTabControl.Controls.Add(this.TabController);
+            this.ConfigTabControl.Controls.Add(this.TabDebugging);
             resources.ApplyResources(this.ConfigTabControl, "ConfigTabControl");
             this.ConfigTabControl.Name = "ConfigTabControl";
             this.ConfigTabControl.SelectedIndex = 0;
@@ -64,7 +70,6 @@
             // TabGeneralSettings
             // 
             this.TabGeneralSettings.Controls.Add(this.InputSkipIntros);
-            this.TabGeneralSettings.Controls.Add(this.InputAttachConsole);
             this.TabGeneralSettings.Controls.Add(this.InputResoSelect);
             this.TabGeneralSettings.Controls.Add(this.InputInstanceCount);
             this.TabGeneralSettings.Controls.Add(this.LabelResolution);
@@ -81,13 +86,6 @@
             this.InputSkipIntros.Name = "InputSkipIntros";
             this.InputSkipIntros.UseVisualStyleBackColor = true;
             this.InputSkipIntros.CheckedChanged += new System.EventHandler(this.InputSkipIntros_CheckedChanged);
-            // 
-            // InputAttachConsole
-            // 
-            resources.ApplyResources(this.InputAttachConsole, "InputAttachConsole");
-            this.InputAttachConsole.Name = "InputAttachConsole";
-            this.InputAttachConsole.UseVisualStyleBackColor = true;
-            this.InputAttachConsole.CheckedChanged += new System.EventHandler(this.InputAttachConsole_CheckedChanged);
             // 
             // InputResoSelect
             // 
@@ -165,10 +163,61 @@
             // ControllerPlayerList
             // 
             resources.ApplyResources(this.ControllerPlayerList, "ControllerPlayerList");
+            this.ControllerPlayerList.HideSelection = false;
             this.ControllerPlayerList.MultiSelect = false;
             this.ControllerPlayerList.Name = "ControllerPlayerList";
             this.ControllerPlayerList.UseCompatibleStateImageBehavior = false;
             this.ControllerPlayerList.SelectedIndexChanged += new System.EventHandler(this.ControllerPlayerList_SelectedIndexChanged);
+            // 
+            // TabDebugging
+            // 
+            this.TabDebugging.Controls.Add(this.ConsoleVerbositySelect);
+            this.TabDebugging.Controls.Add(this.LabelConsoleVerbosity);
+            this.TabDebugging.Controls.Add(this.LogFileVerbositySelect);
+            this.TabDebugging.Controls.Add(this.LabelDebugFileVerb);
+            resources.ApplyResources(this.TabDebugging, "TabDebugging");
+            this.TabDebugging.Name = "TabDebugging";
+            this.TabDebugging.UseVisualStyleBackColor = true;
+            // 
+            // ConsoleVerbositySelect
+            // 
+            this.ConsoleVerbositySelect.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.ConsoleVerbositySelect.FormattingEnabled = true;
+            this.ConsoleVerbositySelect.Items.AddRange(new object[] {
+            resources.GetString("ConsoleVerbositySelect.Items"),
+            resources.GetString("ConsoleVerbositySelect.Items1"),
+            resources.GetString("ConsoleVerbositySelect.Items2"),
+            resources.GetString("ConsoleVerbositySelect.Items3"),
+            resources.GetString("ConsoleVerbositySelect.Items4"),
+            resources.GetString("ConsoleVerbositySelect.Items5")});
+            resources.ApplyResources(this.ConsoleVerbositySelect, "ConsoleVerbositySelect");
+            this.ConsoleVerbositySelect.Name = "ConsoleVerbositySelect";
+            this.ConsoleVerbositySelect.SelectedIndexChanged += new System.EventHandler(this.ConsoleVerbositySelect_SelectedIndexChanged);
+            // 
+            // LabelConsoleVerbosity
+            // 
+            resources.ApplyResources(this.LabelConsoleVerbosity, "LabelConsoleVerbosity");
+            this.LabelConsoleVerbosity.Name = "LabelConsoleVerbosity";
+            // 
+            // LogFileVerbositySelect
+            // 
+            this.LogFileVerbositySelect.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.LogFileVerbositySelect.FormattingEnabled = true;
+            this.LogFileVerbositySelect.Items.AddRange(new object[] {
+            resources.GetString("LogFileVerbositySelect.Items"),
+            resources.GetString("LogFileVerbositySelect.Items1"),
+            resources.GetString("LogFileVerbositySelect.Items2"),
+            resources.GetString("LogFileVerbositySelect.Items3"),
+            resources.GetString("LogFileVerbositySelect.Items4"),
+            resources.GetString("LogFileVerbositySelect.Items5")});
+            resources.ApplyResources(this.LogFileVerbositySelect, "LogFileVerbositySelect");
+            this.LogFileVerbositySelect.Name = "LogFileVerbositySelect";
+            this.LogFileVerbositySelect.SelectedIndexChanged += new System.EventHandler(this.LogFileVerbositySelect_SelectedIndexChanged);
+            // 
+            // LabelDebugFileVerb
+            // 
+            resources.ApplyResources(this.LabelDebugFileVerb, "LabelDebugFileVerb");
+            this.LabelDebugFileVerb.Name = "LabelDebugFileVerb";
             // 
             // ButtonLaunch
             // 
@@ -202,6 +251,8 @@
             this.TabController.ResumeLayout(false);
             this.ControllerOptionsPanel.ResumeLayout(false);
             this.ControllerOptionsPanel.PerformLayout();
+            this.TabDebugging.ResumeLayout(false);
+            this.TabDebugging.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -222,8 +273,12 @@
         private System.Windows.Forms.ComboBox InputControllerSelect;
         private System.Windows.Forms.Button ControllerBTResetAll;
         private System.Windows.Forms.ListView ControllerPlayerList;
-        private System.Windows.Forms.CheckBox InputAttachConsole;
         private System.Windows.Forms.CheckBox InputSkipIntros;
         private System.Windows.Forms.LinkLabel NewVerLink;
+        private System.Windows.Forms.TabPage TabDebugging;
+        private System.Windows.Forms.ComboBox LogFileVerbositySelect;
+        private System.Windows.Forms.Label LabelDebugFileVerb;
+        private System.Windows.Forms.ComboBox ConsoleVerbositySelect;
+        private System.Windows.Forms.Label LabelConsoleVerbosity;
     }
 }

--- a/Launcher/Setup.cs
+++ b/Launcher/Setup.cs
@@ -38,10 +38,6 @@
                 UpdateSettings(this.settings);
                 EnterConfigTab();
                 ConfigTabControl.Enabled = true;
-#if DEBUG
-                InputAttachConsole.Enabled = true;
-                InputAttachConsole.Visible = true;
-#endif
             },
             CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.FromCurrentSynchronizationContext());
         }
@@ -198,9 +194,10 @@
         private void UpdateSettings(Settings oldSettings)
         {
             InputInstanceCount.Value = settings.InstanceCount;
-            InputAttachConsole.Checked = settings.XMLAttachConsole[0];
             settings.SkipIntros = oldSettings.SkipIntros;
             InputSkipIntros.Checked = settings.SkipIntros;
+            ConsoleVerbositySelect.SelectedItem = settings.ConsoleVerbosity.ToString();
+            LogFileVerbositySelect.SelectedItem = settings.LogFileVerbosity.ToString();
             RECT res = (oldSettings.GetWindowPos().Equals(RECT.Zero) ? new RECT(0, 0, 640, 480) : oldSettings.GetWindowPos());
             settings.SetDefaultWindowPos(res.Width, res.Height);
         }
@@ -345,11 +342,6 @@
             }
         }
 
-        private void InputAttachConsole_CheckedChanged(object sender, EventArgs e)
-        {
-            settings.AttachConsoleToAll(InputAttachConsole.Checked);
-        }
-
         private void InputSkipIntros_CheckedChanged(object sender, EventArgs e)
         {
             settings.SkipIntros = InputSkipIntros.Checked;
@@ -358,6 +350,16 @@
         private void NewVerLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             System.Diagnostics.Process.Start("https://github.com/DeadlySurprise/FO2-Splitscreen/releases");
+        }
+
+        private void LogFileVerbositySelect_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            settings.LogFileVerbosity = (LogLevel)Enum.Parse(typeof(LogLevel), LogFileVerbositySelect.SelectedItem.ToString());
+        }
+
+        private void ConsoleVerbositySelect_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            settings.ConsoleVerbosity = (LogLevel)Enum.Parse(typeof(LogLevel), ConsoleVerbositySelect.SelectedItem.ToString());
         }
     }
 }

--- a/Launcher/Setup.resx
+++ b/Launcher/Setup.resx
@@ -117,159 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&gt;&gt;TabGeneralSettings.Name" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;TabGeneralSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TabGeneralSettings.Parent" xml:space="preserve">
-    <value>ConfigTabControl</value>
-  </data>
-  <data name="&gt;&gt;TabGeneralSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;TabController.Name" xml:space="preserve">
-    <value>TabController</value>
-  </data>
-  <data name="&gt;&gt;TabController.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TabController.Parent" xml:space="preserve">
-    <value>ConfigTabControl</value>
-  </data>
-  <data name="&gt;&gt;TabController.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="ConfigTabControl.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ConfigTabControl.Location" type="System.Drawing.Point, System.Drawing">
-    <value>1, -1</value>
-  </data>
-  <data name="ConfigTabControl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>282, 220</value>
-  </data>
-  <data name="ConfigTabControl.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ConfigTabControl.Name" xml:space="preserve">
-    <value>ConfigTabControl</value>
-  </data>
-  <data name="&gt;&gt;ConfigTabControl.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ConfigTabControl.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ConfigTabControl.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;InputSkipIntros.Name" xml:space="preserve">
-    <value>InputSkipIntros</value>
-  </data>
-  <data name="&gt;&gt;InputSkipIntros.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputSkipIntros.Parent" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;InputSkipIntros.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;InputAttachConsole.Name" xml:space="preserve">
-    <value>InputAttachConsole</value>
-  </data>
-  <data name="&gt;&gt;InputAttachConsole.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputAttachConsole.Parent" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;InputAttachConsole.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;InputResoSelect.Name" xml:space="preserve">
-    <value>InputResoSelect</value>
-  </data>
-  <data name="&gt;&gt;InputResoSelect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputResoSelect.Parent" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;InputResoSelect.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;InputInstanceCount.Name" xml:space="preserve">
-    <value>InputInstanceCount</value>
-  </data>
-  <data name="&gt;&gt;InputInstanceCount.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputInstanceCount.Parent" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;InputInstanceCount.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;LabelResolution.Name" xml:space="preserve">
-    <value>LabelResolution</value>
-  </data>
-  <data name="&gt;&gt;LabelResolution.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelResolution.Parent" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;LabelResolution.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;LabelInstances.Name" xml:space="preserve">
-    <value>LabelInstances</value>
-  </data>
-  <data name="&gt;&gt;LabelInstances.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelInstances.Parent" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;LabelInstances.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="TabGeneralSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="TabGeneralSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="TabGeneralSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>274, 194</value>
-  </data>
-  <data name="TabGeneralSettings.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="TabGeneralSettings.Text" xml:space="preserve">
-    <value>General</value>
-  </data>
-  <data name="&gt;&gt;TabGeneralSettings.Name" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;TabGeneralSettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TabGeneralSettings.Parent" xml:space="preserve">
-    <value>ConfigTabControl</value>
-  </data>
-  <data name="&gt;&gt;TabGeneralSettings.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="InputSkipIntros.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="InputSkipIntros.Location" type="System.Drawing.Point, System.Drawing">
     <value>7, 171</value>
   </data>
@@ -294,39 +146,6 @@
   <data name="&gt;&gt;InputSkipIntros.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="InputAttachConsole.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="InputAttachConsole.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="InputAttachConsole.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 148</value>
-  </data>
-  <data name="InputAttachConsole.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 17</value>
-  </data>
-  <data name="InputAttachConsole.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="InputAttachConsole.Text" xml:space="preserve">
-    <value>Attach console</value>
-  </data>
-  <data name="InputAttachConsole.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;InputAttachConsole.Name" xml:space="preserve">
-    <value>InputAttachConsole</value>
-  </data>
-  <data name="&gt;&gt;InputAttachConsole.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputAttachConsole.Parent" xml:space="preserve">
-    <value>TabGeneralSettings</value>
-  </data>
-  <data name="&gt;&gt;InputAttachConsole.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="InputResoSelect.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -349,7 +168,7 @@
     <value>TabGeneralSettings</value>
   </data>
   <data name="&gt;&gt;InputResoSelect.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="InputInstanceCount.Location" type="System.Drawing.Point, System.Drawing">
     <value>82, 3</value>
@@ -370,11 +189,12 @@
     <value>TabGeneralSettings</value>
   </data>
   <data name="&gt;&gt;InputInstanceCount.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="LabelResolution.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="LabelResolution.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -400,7 +220,7 @@
     <value>TabGeneralSettings</value>
   </data>
   <data name="&gt;&gt;LabelResolution.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>3</value>
   </data>
   <data name="LabelInstances.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -427,114 +247,33 @@
     <value>TabGeneralSettings</value>
   </data>
   <data name="&gt;&gt;LabelInstances.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>4</value>
   </data>
-  <data name="&gt;&gt;ControllerOptionsPanel.Name" xml:space="preserve">
-    <value>ControllerOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;ControllerOptionsPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ControllerOptionsPanel.Parent" xml:space="preserve">
-    <value>TabController</value>
-  </data>
-  <data name="&gt;&gt;ControllerOptionsPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;ControllerBTResetAll.Name" xml:space="preserve">
-    <value>ControllerBTResetAll</value>
-  </data>
-  <data name="&gt;&gt;ControllerBTResetAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ControllerBTResetAll.Parent" xml:space="preserve">
-    <value>TabController</value>
-  </data>
-  <data name="&gt;&gt;ControllerBTResetAll.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ControllerPlayerList.Name" xml:space="preserve">
-    <value>ControllerPlayerList</value>
-  </data>
-  <data name="&gt;&gt;ControllerPlayerList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ControllerPlayerList.Parent" xml:space="preserve">
-    <value>TabController</value>
-  </data>
-  <data name="&gt;&gt;ControllerPlayerList.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="TabController.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="TabGeneralSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <data name="TabController.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="TabGeneralSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="TabGeneralSettings.Size" type="System.Drawing.Size, System.Drawing">
     <value>274, 194</value>
   </data>
-  <data name="TabController.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="TabController.Text" xml:space="preserve">
-    <value>Controllers</value>
-  </data>
-  <data name="&gt;&gt;TabController.Name" xml:space="preserve">
-    <value>TabController</value>
-  </data>
-  <data name="&gt;&gt;TabController.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TabController.Parent" xml:space="preserve">
-    <value>ConfigTabControl</value>
-  </data>
-  <data name="&gt;&gt;TabController.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;LabelSelectController.Name" xml:space="preserve">
-    <value>LabelSelectController</value>
-  </data>
-  <data name="&gt;&gt;LabelSelectController.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LabelSelectController.Parent" xml:space="preserve">
-    <value>ControllerOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;LabelSelectController.ZOrder" xml:space="preserve">
+  <data name="TabGeneralSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;InputControllerSelect.Name" xml:space="preserve">
-    <value>InputControllerSelect</value>
+  <data name="TabGeneralSettings.Text" xml:space="preserve">
+    <value>General</value>
   </data>
-  <data name="&gt;&gt;InputControllerSelect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;TabGeneralSettings.Name" xml:space="preserve">
+    <value>TabGeneralSettings</value>
   </data>
-  <data name="&gt;&gt;InputControllerSelect.Parent" xml:space="preserve">
-    <value>ControllerOptionsPanel</value>
+  <data name="&gt;&gt;TabGeneralSettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;InputControllerSelect.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;TabGeneralSettings.Parent" xml:space="preserve">
+    <value>ConfigTabControl</value>
   </data>
-  <data name="ControllerOptionsPanel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="ControllerOptionsPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>106, 4</value>
-  </data>
-  <data name="ControllerOptionsPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>161, 158</value>
-  </data>
-  <data name="ControllerOptionsPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;ControllerOptionsPanel.Name" xml:space="preserve">
-    <value>ControllerOptionsPanel</value>
-  </data>
-  <data name="&gt;&gt;ControllerOptionsPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ControllerOptionsPanel.Parent" xml:space="preserve">
-    <value>TabController</value>
-  </data>
-  <data name="&gt;&gt;ControllerOptionsPanel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;TabGeneralSettings.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="LabelSelectController.AutoSize" type="System.Boolean, mscorlib">
@@ -585,6 +324,30 @@
   <data name="&gt;&gt;InputControllerSelect.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="ControllerOptionsPanel.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ControllerOptionsPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>106, 4</value>
+  </data>
+  <data name="ControllerOptionsPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>161, 158</value>
+  </data>
+  <data name="ControllerOptionsPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ControllerOptionsPanel.Name" xml:space="preserve">
+    <value>ControllerOptionsPanel</value>
+  </data>
+  <data name="&gt;&gt;ControllerOptionsPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ControllerOptionsPanel.Parent" xml:space="preserve">
+    <value>TabController</value>
+  </data>
+  <data name="&gt;&gt;ControllerOptionsPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="ControllerBTResetAll.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -634,6 +397,216 @@
     <value>TabController</value>
   </data>
   <data name="&gt;&gt;ControllerPlayerList.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="TabController.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="TabController.Size" type="System.Drawing.Size, System.Drawing">
+    <value>274, 194</value>
+  </data>
+  <data name="TabController.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="TabController.Text" xml:space="preserve">
+    <value>Controllers</value>
+  </data>
+  <data name="&gt;&gt;TabController.Name" xml:space="preserve">
+    <value>TabController</value>
+  </data>
+  <data name="&gt;&gt;TabController.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TabController.Parent" xml:space="preserve">
+    <value>ConfigTabControl</value>
+  </data>
+  <data name="&gt;&gt;TabController.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ConsoleVerbositySelect.Items" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="ConsoleVerbositySelect.Items1" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="ConsoleVerbositySelect.Items2" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="ConsoleVerbositySelect.Items3" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="ConsoleVerbositySelect.Items4" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="ConsoleVerbositySelect.Items5" xml:space="preserve">
+    <value>Trace</value>
+  </data>
+  <data name="ConsoleVerbositySelect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>95, 44</value>
+  </data>
+  <data name="ConsoleVerbositySelect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="ConsoleVerbositySelect.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;ConsoleVerbositySelect.Name" xml:space="preserve">
+    <value>ConsoleVerbositySelect</value>
+  </data>
+  <data name="&gt;&gt;ConsoleVerbositySelect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ConsoleVerbositySelect.Parent" xml:space="preserve">
+    <value>TabDebugging</value>
+  </data>
+  <data name="&gt;&gt;ConsoleVerbositySelect.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="LabelConsoleVerbosity.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LabelConsoleVerbosity.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="LabelConsoleVerbosity.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 47</value>
+  </data>
+  <data name="LabelConsoleVerbosity.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 13</value>
+  </data>
+  <data name="LabelConsoleVerbosity.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="LabelConsoleVerbosity.Text" xml:space="preserve">
+    <value>Console verbosity:</value>
+  </data>
+  <data name="&gt;&gt;LabelConsoleVerbosity.Name" xml:space="preserve">
+    <value>LabelConsoleVerbosity</value>
+  </data>
+  <data name="&gt;&gt;LabelConsoleVerbosity.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LabelConsoleVerbosity.Parent" xml:space="preserve">
+    <value>TabDebugging</value>
+  </data>
+  <data name="&gt;&gt;LabelConsoleVerbosity.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="LogFileVerbositySelect.Items" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="LogFileVerbositySelect.Items1" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="LogFileVerbositySelect.Items2" xml:space="preserve">
+    <value>Warning</value>
+  </data>
+  <data name="LogFileVerbositySelect.Items3" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="LogFileVerbositySelect.Items4" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="LogFileVerbositySelect.Items5" xml:space="preserve">
+    <value>Trace</value>
+  </data>
+  <data name="LogFileVerbositySelect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>95, 13</value>
+  </data>
+  <data name="LogFileVerbositySelect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="LogFileVerbositySelect.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;LogFileVerbositySelect.Name" xml:space="preserve">
+    <value>LogFileVerbositySelect</value>
+  </data>
+  <data name="&gt;&gt;LogFileVerbositySelect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LogFileVerbositySelect.Parent" xml:space="preserve">
+    <value>TabDebugging</value>
+  </data>
+  <data name="&gt;&gt;LogFileVerbositySelect.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="LabelDebugFileVerb.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LabelDebugFileVerb.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="LabelDebugFileVerb.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 16</value>
+  </data>
+  <data name="LabelDebugFileVerb.Size" type="System.Drawing.Size, System.Drawing">
+    <value>89, 13</value>
+  </data>
+  <data name="LabelDebugFileVerb.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="LabelDebugFileVerb.Text" xml:space="preserve">
+    <value>Log file verbosity:</value>
+  </data>
+  <data name="&gt;&gt;LabelDebugFileVerb.Name" xml:space="preserve">
+    <value>LabelDebugFileVerb</value>
+  </data>
+  <data name="&gt;&gt;LabelDebugFileVerb.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LabelDebugFileVerb.Parent" xml:space="preserve">
+    <value>TabDebugging</value>
+  </data>
+  <data name="&gt;&gt;LabelDebugFileVerb.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="TabDebugging.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="TabDebugging.Size" type="System.Drawing.Size, System.Drawing">
+    <value>274, 194</value>
+  </data>
+  <data name="TabDebugging.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="TabDebugging.Text" xml:space="preserve">
+    <value>Debugging</value>
+  </data>
+  <data name="&gt;&gt;TabDebugging.Name" xml:space="preserve">
+    <value>TabDebugging</value>
+  </data>
+  <data name="&gt;&gt;TabDebugging.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TabDebugging.Parent" xml:space="preserve">
+    <value>ConfigTabControl</value>
+  </data>
+  <data name="&gt;&gt;TabDebugging.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="ConfigTabControl.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ConfigTabControl.Location" type="System.Drawing.Point, System.Drawing">
+    <value>1, -1</value>
+  </data>
+  <data name="ConfigTabControl.Size" type="System.Drawing.Size, System.Drawing">
+    <value>282, 220</value>
+  </data>
+  <data name="ConfigTabControl.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;ConfigTabControl.Name" xml:space="preserve">
+    <value>ConfigTabControl</value>
+  </data>
+  <data name="&gt;&gt;ConfigTabControl.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ConfigTabControl.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ConfigTabControl.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="ButtonLaunch.Location" type="System.Drawing.Point, System.Drawing">


### PR DESCRIPTION
Verbosity levels can be independently set for both outputs.  

These can be configured in the launcher and via two new settings in the XML. The `attachConsole` settings was removed.   
Logs from all game processes are merged into a single file `log.txt` which is placed into the game's root folder. In the future a rotating log could be helpful.
Disk IO is handled by a separate thread so no performance impact should occur in-game.
