### PR TITLE
Fixed no games found in steam version

### DIFF
--- a/FlatOut2/WinSockDetours.cpp
+++ b/FlatOut2/WinSockDetours.cpp
@@ -80,6 +80,11 @@ int WSAAPI MyCleanup()
 int WSAAPI MyWSAStart(WORD wVersionRequested, LPWSADATA lpWSAData)
 {
 	int r = ((WSAStart)oWSAStart)(wVersionRequested, lpWSAData);
+	if (virtIP) {
+		Logging::getInstance().warn("NETWORK", "Game called WinSock WSAStartup more than once.");
+		return r;
+	}
+
 	if (r == 0)
 	{
 #if oCall_Count != 10


### PR DESCRIPTION
Fixes #18.

The Steam version of the game called WSAStartup twice which is the entry point for the creation of the mods virtual network. This caused the virtual network of the host instance to attempt to bind a port twice.  

The second call of WSAStartup now logs a warning and passes through to the original function without creating the virtual network multiple times.